### PR TITLE
Dispatch source_saved signal in a stable order

### DIFF
--- a/imagekit/specs/sourcegroups.py
+++ b/imagekit/specs/sourcegroups.py
@@ -84,10 +84,11 @@ class ModelSignalRouter:
         Returns a list of the source fields for the given instance.
 
         """
-        return {
+        # Filter out duplicates while preserving the order.
+        return list(dict.fromkeys(
             src.image_field
             for src in self._source_groups
-            if isinstance(instance, src.model_class)}
+            if isinstance(instance, src.model_class)))
 
     @ik_model_receiver
     def post_save_receiver(self, sender, instance=None, created=False, update_fields=None, raw=False, **kwargs):

--- a/tests/models.py
+++ b/tests/models.py
@@ -27,6 +27,9 @@ class Photo(models.Model):
             sharpness=1.1), SmartCrop(50, 50)], source='original_image',
             format='JPEG', options={'quality': 90})
 
+    thumbnail_of_thumbnail = ImageSpecField([ResizeToFill(10, 10)], source='thumbnail',
+            format='JPEG', options={'quality': 90})
+
 
 class ProcessedImageFieldModel(models.Model):
     processed = ProcessedImageField([SmartCrop(50, 50)], format='JPEG',

--- a/tests/test_sourcegroups.py
+++ b/tests/test_sourcegroups.py
@@ -2,18 +2,19 @@ import pytest
 from django.core.files import File
 
 from imagekit.signals import source_saved
-from imagekit.specs.sourcegroups import ImageFieldSourceGroup
 
-from .models import AbstractImageModel, ConcreteImageModel, ImageModel
+from .models import AbstractImageModel, ConcreteImageModel, ImageModel, Photo
 from .utils import get_image_file
 
 
-def make_counting_receiver(source_group):
-    def receiver(sender, *args, **kwargs):
-        if sender is source_group:
-            receiver.count += 1
-    receiver.count = 0
-    return receiver
+def make_logging_receiver():
+    logs = []
+
+    def receiver(sender, signal, source):
+        # image_field is the name of the source field.
+        logs.append((sender.image_field, sender.model_class))
+
+    return receiver, logs
 
 
 @pytest.mark.django_db(transaction=True)
@@ -23,12 +24,12 @@ def test_source_saved_signal():
     dispatched.
 
     """
-    source_group = ImageFieldSourceGroup(ImageModel, 'image')
-    receiver = make_counting_receiver(source_group)
+    receiver, logs = make_logging_receiver()
     source_saved.connect(receiver)
     with File(get_image_file(), name='reference.png') as image:
-        ImageModel.objects.create(image=image)
-    assert receiver.count == 1
+        Photo.objects.create(original_image=image)
+    assert logs == [('original_image', Photo), ('original_image', Photo),
+                    ('thumbnail', Photo)]
 
 
 @pytest.mark.django_db(transaction=True)
@@ -40,11 +41,10 @@ def test_no_source_saved_signal():
     https://github.com/matthewwithanm/django-imagekit/issues/214
 
     """
-    source_group = ImageFieldSourceGroup(ImageModel, 'image')
-    receiver = make_counting_receiver(source_group)
+    receiver, logs = make_logging_receiver()
     source_saved.connect(receiver)
     ImageModel.objects.create()
-    assert receiver.count == 0
+    assert logs == []
 
 
 @pytest.mark.django_db(transaction=True)
@@ -54,9 +54,8 @@ def test_abstract_model_signals():
     dispatched on their concrete subclasses.
 
     """
-    source_group = ImageFieldSourceGroup(AbstractImageModel, 'original_image')
-    receiver = make_counting_receiver(source_group)
+    receiver, logs = make_logging_receiver()
     source_saved.connect(receiver)
     with File(get_image_file(), name='reference.png') as image:
         ConcreteImageModel.objects.create(original_image=image)
-    assert receiver.count == 1
+    assert logs == [('original_image', AbstractImageModel)]


### PR DESCRIPTION
This PR ensures `ImageSpecField`s receive the `source_saved` signal in the order the fields are created. Currently the order is unstable due to the use of `set`.

This change is neccessary when I have `IMAGEKIT_DEFAULT_CACHEFILE_STRATEGY` set to `imagekit.cachefiles.strategies.Optimistic` and have a `ImageSpecField` that generates images from another `ImageSpecField`, like so:

```py
class Photo(models.Model):
    original = models.ImageField(upload_to='photos')
    thumb_1 = ImageSpecField([ResizeToFill(1200, 1200)], source='original', format='JPEG', 'quality': 90})
    thumb_2 = ImageSpecField([ResizeToFill(600, 600)], source='thumb_1 format='JPEG', 'quality': 90})
```

Here, it is important thumb_1 receives the source_saved signal before thumb_2, otherwise thumb_2 tries to create it's thumbnail from the thumb_1's file, which does not yet exist at that time.